### PR TITLE
chore(CI): 🔒 add security permissions and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for automatic dependency updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # NPM dependencies (TypeScript, build tools)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Group all non-major updates together
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Rust/Cargo dependencies (WASM)
+  - package-ecosystem: "cargo"
+    directory: "/wasm"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Group all non-major updates together
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Security Improvements

### CI Permissions
- ✅ Add explicit `contents: read` permission to CI workflow
- Follows principle of least privilege for GitHub Actions
- Prevents accidental writes or privilege escalation

### Dependabot Configuration
- ✅ Monitor **npm** dependencies (TypeScript, build tools)
- ✅ Monitor **Cargo** dependencies (Rust/WASM)
- ✅ Monitor **GitHub Actions** versions
- Weekly update schedule
- Group minor/patch updates to reduce PR noise
- Max 10 PRs for npm/cargo, 5 for actions

## Benefits

1. **Security**: Automated vulnerability patches
2. **Maintenance**: Stay up-to-date with dependencies
3. **Organization**: Grouped updates reduce notification fatigue

GitHub also detected 1 moderate vulnerability - Dependabot will create a fix PR automatically once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)